### PR TITLE
投稿詳細ページ・投稿一覧ページのUI作成

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -2,13 +2,17 @@ import { client } from '@/libs/client';
 import Image from 'next/image';
 import React, { FC } from 'react';
 import parse from 'html-react-parser';
+import dayjs from 'dayjs';
+import ja from 'dayjs/locale/ja';
 
 const Blog = async ({ params }: { params: { id: string } }) => {
   const data = await client.get({ endpoint: 'blog', contentId: params.id });
 
+  const updatedAt = dayjs(data.updatedAt).locale(ja);
+  const formatedUpdatedAt = updatedAt.format('YYYY-MM-DD HH:mm');
+
   return (
     <main className="my-12">
-      {/* <p></p> */}
       <div className="border border-gray-500">
         <Image
           src={data.topImage.url}
@@ -18,6 +22,7 @@ const Blog = async ({ params }: { params: { id: string } }) => {
           className="mx-auto"
         />
       </div>
+      <p className="text-right text-gray-500 my-4">{formatedUpdatedAt}</p>
       <h2 className="h-12 my-4 font-bold text-2xl">{data.title}</h2>
       <div className="text-right">
         <p className="inline-block text-sm tracking-wider bg-black text-white mt-2 p-4">

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,14 +1,10 @@
+import { client } from '@/libs/client';
 import Link from 'next/link';
 import Image from 'next/image';
-import React, { FC } from 'react';
-import { client } from '@/libs/client';
+import React from 'react';
 
-type Props = {
-  id: string;
-};
-
-const BlogItem: FC<Props> = async (props: Props) => {
-  const data = await client.get({ endpoint: 'blog', contentId: props.id });
+const pages = async ({ params }: { params: { id: string } }) => {
+  const data = await client.get({ endpoint: 'blog', contentId: params.id });
 
   return (
     <li>
@@ -32,4 +28,4 @@ const BlogItem: FC<Props> = async (props: Props) => {
   );
 };
 
-export default BlogItem;
+export default pages;

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -2,29 +2,29 @@ import { client } from '@/libs/client';
 import Link from 'next/link';
 import Image from 'next/image';
 import React from 'react';
+import parse from 'html-react-parser';
 
 const pages = async ({ params }: { params: { id: string } }) => {
   const data = await client.get({ endpoint: 'blog', contentId: params.id });
 
   return (
-    <li>
-      <Link href={`blog/${data.id}`} className="hover:opacity-50">
-        <div className="border border-gray-500">
-          <Image
-            src={data.topImage.url}
-            alt="topImage"
-            width={data.topImage.width}
-            height={data.topImage.height}
-          />
-        </div>
-        <h2 className="h-12 my-4 font-bold text-md">{data.title}</h2>
-        <div className="text-right">
-          <p className="inline-block text-sm tracking-wider bg-black text-white mt-2 p-4">
-            {data.categories}
-          </p>
-        </div>
-      </Link>
-    </li>
+    <div>
+      <div className="border border-gray-500">
+        <Image
+          src={data.topImage.url}
+          alt="topImage"
+          width={data.topImage.width}
+          height={data.topImage.height}
+        />
+      </div>
+      <h2 className="h-12 my-4 font-bold text-md">{data.title}</h2>
+      <div className="text-right">
+        <p className="inline-block text-sm tracking-wider bg-black text-white mt-2 p-4">
+          {data.categories}
+        </p>
+      </div>
+      <article>{parse(data.body)}</article>
+    </div>
   );
 };
 

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,31 +1,32 @@
 import { client } from '@/libs/client';
-import Link from 'next/link';
 import Image from 'next/image';
-import React from 'react';
+import React, { FC } from 'react';
 import parse from 'html-react-parser';
 
-const pages = async ({ params }: { params: { id: string } }) => {
+const Blog = async ({ params }: { params: { id: string } }) => {
   const data = await client.get({ endpoint: 'blog', contentId: params.id });
 
   return (
-    <div>
+    <main className="my-12">
+      {/* <p></p> */}
       <div className="border border-gray-500">
         <Image
           src={data.topImage.url}
           alt="topImage"
           width={data.topImage.width}
           height={data.topImage.height}
+          className="mx-auto"
         />
       </div>
-      <h2 className="h-12 my-4 font-bold text-md">{data.title}</h2>
+      <h2 className="h-12 my-4 font-bold text-2xl">{data.title}</h2>
       <div className="text-right">
         <p className="inline-block text-sm tracking-wider bg-black text-white mt-2 p-4">
           {data.categories}
         </p>
       </div>
-      <article>{parse(data.body)}</article>
-    </div>
+      <article className="api-article">{parse(data.body)}</article>
+    </main>
   );
 };
 
-export default pages;
+export default Blog;

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
           </p>
         </div>
       </div>
-      <nav className="my-8">
+      <nav className="my-6">
         <ul className="py-4 flex items-center justify-around bg-black text-white tracking-widest">
           <li>
             <Link href="/" className="hover:text-gray-300">
@@ -25,7 +25,7 @@ const Header = () => {
             </Link>
           </li>
           <li>
-            <Link href="" className="hover:text-gray-300">
+            <Link href="/env" className="hover:text-gray-300">
               PC・周辺機器
             </Link>
           </li>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -30,17 +30,17 @@ const Header = () => {
             </Link>
           </li>
           <li>
-            <Link href="" className="hover:text-gray-300">
+            <Link href="/tech" className="hover:text-gray-300">
               Web技術関連
             </Link>
           </li>
           <li>
-            <Link href="" className="hover:text-gray-300">
+            <Link href="ds" className="hover:text-gray-300">
               DS・ML・業務効率化
             </Link>
           </li>
           <li>
-            <Link href="" className="hover:text-gray-300">
+            <Link href="talk" className="hover:text-gray-300">
               雑談
             </Link>
           </li>

--- a/app/ds/page.tsx
+++ b/app/ds/page.tsx
@@ -1,0 +1,40 @@
+import { client } from '../../libs/client';
+import BlogItem from '../components/BlogItem';
+
+interface Image {
+  url: string;
+  height: number;
+  width: number;
+}
+
+interface Article {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  topImage: Image;
+  title: string;
+  body: string;
+  categories: string[];
+}
+
+export default async function Home() {
+  const data = await client.getAllContents({ endpoint: 'blog' });
+  const filteredData = data.filter((item: Article, i) =>
+    item.categories.some((category) => category === 'DS・ML・業務効率化'),
+  );
+
+  return (
+    <main className="my-4">
+      <h2 className="py-4 font-bold text-xl tracking-wider">
+        DS・ML・業務効率化の記事一覧
+      </h2>
+      <ul className="grid grid-cols-3 gap-6">
+        {filteredData.map((item: Article, i) => (
+          <BlogItem key={i} id={item.id} />
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/env/page.tsx
+++ b/app/env/page.tsx
@@ -1,0 +1,40 @@
+import { client } from '../../libs/client';
+import BlogItem from '../components/BlogItem';
+
+interface Image {
+  url: string;
+  height: number;
+  width: number;
+}
+
+interface Article {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  topImage: Image;
+  title: string;
+  body: string;
+  categories: string[];
+}
+
+export default async function Home() {
+  const data = await client.getAllContents({ endpoint: 'blog' });
+  const filteredData = data.filter((item: Article, i) =>
+    item.categories.some((category) => category === 'PC・周辺機器'),
+  );
+
+  return (
+    <main className="my-4">
+      <h2 className="py-4 font-bold text-xl tracking-wider">
+        PC・周辺機器の記事一覧
+      </h2>
+      <ul className="grid grid-cols-3 gap-6">
+        {filteredData.map((item: Article, i) => (
+          <BlogItem key={i} id={item.id} />
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,3 +3,66 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.api-article {
+    line-height: 1.8;
+}
+
+.api-article h1 {
+    margin: 2rem 0;
+    padding: 1rem;
+    font-size: 1.2rem;
+    font-family: 'Zen Kaku Gothic New';
+    font-weight: bold;
+    background-color: #d9d9d9;
+    border-left: 10px black solid;
+    letter-spacing: 0.05em;
+}
+
+
+.api-article h2 {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    font-size: 1.2rem;
+    font-family: 'Zen Kaku Gothic New';
+    letter-spacing: 0.05em;
+    border-bottom: solid 1px black;
+	margin-bottom: 4px;
+	position: relative;
+}
+
+.api-article h2:before {
+    content: '';
+    width: 100%;
+    height: 1px;
+    border-bottom: solid 1px;
+    position: absolute;
+    left: 0px;
+    bottom: -5px;
+}
+
+.api-article h3 {
+    font-weight: medium;
+    font-size: 1.2rem;
+}
+
+.api-article p {
+    margin: 1rem 0;
+    letter-spacing: 0.05em;
+}
+
+.api-article ul {
+    margin: 1.5rem 0;
+    border: 4px #d9d9d9 dotted;
+    padding: 1.5rem;
+}
+
+.api-article li {
+    margin-left: 1.5rem;
+    list-style-type: disc;
+}
+
+.api-article a {
+    color: gray;
+    text-decoration: underline;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,7 @@ import { client } from '../libs/client';
 import BlogItem from './components/BlogItem';
 
 export default async function Home(): Promise<JSX.Element> {
-  const data = await client.getAllContentIds({ endpoint: 'blog' });
-  const articles = data;
-  console.log(data);
+  const articles = await client.getAllContentIds({ endpoint: 'blog' });
 
   return (
     <main className="py-8">

--- a/app/talk/page.tsx
+++ b/app/talk/page.tsx
@@ -1,0 +1,38 @@
+import { client } from '../../libs/client';
+import BlogItem from '../components/BlogItem';
+
+interface Image {
+  url: string;
+  height: number;
+  width: number;
+}
+
+interface Article {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  topImage: Image;
+  title: string;
+  body: string;
+  categories: string[];
+}
+
+export default async function Home() {
+  const data = await client.getAllContents({ endpoint: 'blog' });
+  const filteredData = data.filter((item: Article, i) =>
+    item.categories.some((category) => category === '雑談'),
+  );
+
+  return (
+    <main className="my-4">
+      <h2 className="py-4 font-bold text-xl tracking-wider">雑談の記事一覧</h2>
+      <ul className="grid grid-cols-3 gap-6">
+        {filteredData.map((item: Article, i) => (
+          <BlogItem key={i} id={item.id} />
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/tech/page.tsx
+++ b/app/tech/page.tsx
@@ -1,0 +1,40 @@
+import { client } from '../../libs/client';
+import BlogItem from '../components/BlogItem';
+
+interface Image {
+  url: string;
+  height: number;
+  width: number;
+}
+
+interface Article {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  topImage: Image;
+  title: string;
+  body: string;
+  categories: string[];
+}
+
+export default async function Home() {
+  const data = await client.getAllContents({ endpoint: 'blog' });
+  const filteredData = data.filter((item: Article, i) =>
+    item.categories.some((category) => category === 'Web技術関連'),
+  );
+
+  return (
+    <main className="my-4">
+      <h2 className="py-4 font-bold text-xl tracking-wider">
+        Web技術関連の記事一覧
+      </h2>
+      <ul className="grid grid-cols-3 gap-6">
+        {filteredData.map((item: Article, i) => (
+          <BlogItem key={i} id={item.id} />
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.17.0",
+        "html-react-parser": "^5.1.12",
         "microcms-js-sdk": "^3.1.2",
         "next": "14.2.5",
         "react": "^18",
@@ -485,14 +486,14 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1394,7 +1395,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -1588,6 +1589,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1614,6 +1670,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -2948,6 +3016,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.9.tgz",
+      "integrity": "sha512-QGeoFYwgQ582EDvrBx0+ejIz76/LuQcwwkmSR4ueKncjl2yWbciA45Kfz/LrHvWR3CgtKnxKFkr4Mpq2Sh1QNg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.12.tgz",
+      "integrity": "sha512-OPv8fsIvxxv/+pLj9mYvyNu8PE5dPMowTRdd5VHpcoZpXlstp8eYCxQ5rzqAE5Tb75rhdiWUXnPltfb62zCVjg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.9",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.12"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18",
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -3024,6 +3142,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -4859,6 +4983,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5546,6 +5676,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+      "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.6"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+      "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.3"
       }
     },
     "node_modules/styled-jsx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.17.0",
+        "dayjs": "^1.11.12",
         "html-react-parser": "^5.1.12",
         "microcms-js-sdk": "^3.1.2",
         "next": "14.2.5",
@@ -1455,6 +1456,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "microcms-js-sdk": "^3.1.2",
         "next": "14.2.5",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "sass": "^1.77.8"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -813,7 +814,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1075,7 +1075,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1196,7 +1195,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -1221,7 +1219,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2664,7 +2661,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3101,6 +3097,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3231,7 +3233,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4336,7 +4337,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5003,7 +5003,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -5244,6 +5243,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "dayjs": "^1.11.12",
     "html-react-parser": "^5.1.12",
     "microcms-js-sdk": "^3.1.2",
     "next": "14.2.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "html-react-parser": "^5.1.12",
     "microcms-js-sdk": "^3.1.2",
     "next": "14.2.5",
     "react": "^18",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "microcms-js-sdk": "^3.1.2",
     "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "sass": "^1.77.8"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
# 関連issue
- close #6 
- close #7

# 達成した挙動
- 投稿詳細ページに遷移するとブログデザインが適用されます
- `/env`、`/tech`、`/ds`、`/talk`において、カテゴリー別の投稿一覧ページが閲覧できます

# 挙動の確認方法
- 投稿をクリックすると投稿詳細ページに遷移します

# 今後の課題
